### PR TITLE
Export Sophys GUI components as Widgets

### DIFF
--- a/sophys_gui/__init__.py
+++ b/sophys_gui/__init__.py
@@ -1,3 +1,6 @@
 """
     This is a GUI for controlling and monitoring a Blueksy instance through HTTP Server and Kafka.
 """
+from .server.model import ServerModel
+from .components.form import SophysForm
+from .components.login import SophysLogin

--- a/sophys_gui/__init__.py
+++ b/sophys_gui/__init__.py
@@ -2,5 +2,6 @@
     This is a GUI for controlling and monitoring a Blueksy instance through HTTP Server and Kafka.
 """
 from .server.model import ServerModel
+from .components.application import SophysApplication
 from .components.form import SophysForm
 from .components.login import SophysLogin

--- a/sophys_gui/__init__.py
+++ b/sophys_gui/__init__.py
@@ -5,3 +5,4 @@ from .server.model import ServerModel
 from .components.application import SophysApplication
 from .components.form import SophysForm
 from .components.login import SophysLogin
+from .components.led import SophysLed

--- a/sophys_gui/_assets/css-style.css
+++ b/sophys_gui/_assets/css-style.css
@@ -70,13 +70,6 @@ QSlider::handle, QLineEdit {
     border-radius: 5px;
 }
 
-#popup QWidget {
-    margin: 1em;
-    background-color: #ffdb3b;
-    border: 1px solid #808080;
-    border-radius: 10px;
-}
-
 QSplitter::handle {
     background: qradialgradient(
         cx: 0.5, cy: 0.5, radius: 0.3,

--- a/sophys_gui/components/__init__.py
+++ b/sophys_gui/components/__init__.py
@@ -6,3 +6,4 @@ from .application import SophysApplication
 from .input import SophysInputList, SophysInputDict, SophysSpinBox, \
     SophysInputMotor
 from .console import SophysConsoleMonitor
+from .login import SophysLogin

--- a/sophys_gui/components/application.py
+++ b/sophys_gui/components/application.py
@@ -114,12 +114,11 @@ class SophysApplication(QApplication):
         """
         popup = PopupWidget(window)
         popup.setVisible(False)
-        popup.setStyleSheet("""{
+        popup.setStyleSheet("""
             margin: 1em;
             background-color: #ffdb3b;
             border: 1px solid #808080;
             border-radius: 10px;
-        }
         """)
         self.popup.append(popup)
 

--- a/sophys_gui/components/application.py
+++ b/sophys_gui/components/application.py
@@ -34,9 +34,19 @@ class SophysApplication(QApplication):
         """
             Generate a generic style for the GUI application.
         """
-        style_file = getFilePath("_assets/css-style.css")
-        with open(style_file, 'r') as f:
-            style = f.read()
+        style = ""
+        if self.use_stylesheet:
+            style_file = getFilePath("_assets/css-style.css")
+            with open(style_file, 'r') as f:
+                style = f.read()
+        style += """
+        #popup QWidget {
+            margin: 1em;
+            background-color: #ffdb3b;
+            border: 1px solid #808080;
+            border-radius: 10px;
+        }
+        """
         self.setStyleSheet(style)
 
     def showBugError(self, exctype, excvalue, tracebackobj):
@@ -120,7 +130,6 @@ class SophysApplication(QApplication):
         self.runEngineClient = client
 
     def _setupUi(self):
-        if self.use_stylesheet:
-            self.setStyle()
+        self.setStyle()
         sys.excepthook = self.excepthook
         signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/sophys_gui/components/application.py
+++ b/sophys_gui/components/application.py
@@ -18,10 +18,11 @@ class SophysApplication(QApplication):
 
     """
 
-    def __init__(self, argv):
+    def __init__(self, argv, use_stylesheet = True):
         super().__init__(argv)
         self.popup = []
         self.runEngineClient = None
+        self.use_stylesheet = use_stylesheet
         self.codeErrors = {
             "001": "Invalid Input type!!",
             "002": "Missing required fields!!",
@@ -119,6 +120,7 @@ class SophysApplication(QApplication):
         self.runEngineClient = client
 
     def _setupUi(self):
-        self.setStyle()
+        if self.use_stylesheet:
+            self.setStyle()
         sys.excepthook = self.excepthook
         signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/sophys_gui/components/application.py
+++ b/sophys_gui/components/application.py
@@ -34,19 +34,9 @@ class SophysApplication(QApplication):
         """
             Generate a generic style for the GUI application.
         """
-        style = ""
-        if self.use_stylesheet:
-            style_file = getFilePath("_assets/css-style.css")
-            with open(style_file, 'r') as f:
-                style = f.read()
-        style += """
-        #popup QWidget {
-            margin: 1em;
-            background-color: #ffdb3b;
-            border: 1px solid #808080;
-            border-radius: 10px;
-        }
-        """
+        style_file = getFilePath("_assets/css-style.css")
+        with open(style_file, 'r') as f:
+            style = f.read()
         self.setStyleSheet(style)
 
     def showBugError(self, exctype, excvalue, tracebackobj):
@@ -124,12 +114,20 @@ class SophysApplication(QApplication):
         """
         popup = PopupWidget(window)
         popup.setVisible(False)
+        popup.setStyleSheet("""{
+            margin: 1em;
+            background-color: #ffdb3b;
+            border: 1px solid #808080;
+            border-radius: 10px;
+        }
+        """)
         self.popup.append(popup)
 
     def saveRunEngineClient(self, client):
         self.runEngineClient = client
 
     def _setupUi(self):
-        self.setStyle()
+        if self.use_stylesheet:
+            self.setStyle()
         sys.excepthook = self.excepthook
         signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -252,6 +252,9 @@ class SophysForm(QDialog):
             if "default" in paramMeta:
                 default = paramMeta["default"]
             inputWid.setPlaceholderText(default)
+        elif isinstance(inputWid, QComboBox):
+            if "default" in paramMeta:
+                inputWid.setCurrentText(paramMeta["default"])
 
     def handleArgsParam(self, argsParams, paramName):
         """

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -584,7 +584,7 @@ class SophysForm(QDialog):
         self.changeCurrentItem(currItem)
         lay.addLayout(self.parametersLayout)
 
-        btns = self.getDialogBtns(len(form_gui_widget) == 0)
+        btns = self.getDialogBtns(len(self.form_gui_widget) == 0)
         lay.addWidget(btns)
 
         app = QApplication.instance()

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -55,7 +55,7 @@ class SophysForm(QDialog):
         self.setupUi()
     
     def accept(self):
-        if not (len(self.form_gui_widget) > 0):
+        if len(self.form_gui_widget) == 0:
             super().accept()
 
     def keyPressEvent(self: QDialog, event: object) -> None:

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -58,10 +58,11 @@ class SophysForm(QDialog):
         """
             Override close dialog on pressing the Enter key.
         """
-        if (event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return) and not (len(self.form_gui_widget) > 0):
-            event.accept()
-        else:
-            super(SophysForm, self).keyPressEvent(event)
+        if not (len(self.form_gui_widget) > 0):
+            if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
+                event.accept()
+            else:
+                super(SophysForm, self).keyPressEvent(event)
 
     def selectedItemMetadata(self):
         """

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -35,7 +35,9 @@ class SophysForm(QDialog):
 
     """
 
-    def __init__(self, model, modalMode, allowedParameters, allowedNames, hasEnv=True, metadata_file_path=""):
+    def __init__(
+            self, model, modalMode, allowedParameters, allowedNames, hasEnv=True, metadata_file_path="",
+            form_gui_widget = ""):
         super().__init__()
         self.allowedParameters = allowedParameters
         self.allowedNames = allowedNames
@@ -47,7 +49,7 @@ class SophysForm(QDialog):
         self.metadata_file_path = None
         self.global_metadata_path = metadata_file_path
         self.itemType = "instruction" if "instruction" in modalMode else "plan"
-        self.setupUi()
+        self.setupUi(form_gui_widget)
 
     def keyPressEvent(self: QDialog, event: object) -> None:
         """
@@ -528,7 +530,7 @@ class SophysForm(QDialog):
         self.plan_description = QLabel()
         vlay.addWidget(self.plan_description)
 
-        if self.itemType == "plan":
+        if self.itemType == "plan" and self.global_metadata_path != "":
             hbox = QHBoxLayout()
             metadata_lbl = QLabel("Metadata File Path")
             hbox.addWidget(metadata_lbl)
@@ -538,7 +540,7 @@ class SophysForm(QDialog):
 
         return group, currItem
 
-    def setupUi(self):
+    def setupUi(self, form_gui_widget):
         self.setMaximumSize(1500, 1000)
         self.setWindowFlags(Qt.WindowStaysOnTopHint)
 
@@ -547,16 +549,19 @@ class SophysForm(QDialog):
         lay = QVBoxLayout(self)
 
         isAddition = "add" in self.modalMode
-        if isAddition:
-            itemCombbox, currItem = self.getGeneralPlanData()
-            lay.addWidget(itemCombbox)
+        if len(form_gui_widget) > 0:
+            currItem = form_gui_widget
         else:
-            currItem = self.selectedItemMetadata()["name"]
+            if isAddition:
+                itemCombbox, currItem = self.getGeneralPlanData()
+                lay.addWidget(itemCombbox)
+            else:
+                currItem = self.selectedItemMetadata()["name"]
 
         self.changeCurrentItem(currItem)
         lay.addLayout(self.parametersLayout)
 
-        btns = self.getDialogBtns()
+        btns = self.getDialogBtns(len(form_gui_widget) == 0)
         lay.addWidget(btns)
 
         app = QApplication.instance()

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -53,16 +53,19 @@ class SophysForm(QDialog):
         self.global_metadata_path = metadata_file_path
         self.itemType = "instruction" if "instruction" in modalMode else "plan"
         self.setupUi()
+    
+    def accept(self):
+        if not (len(self.form_gui_widget) > 0):
+            super().accept()
 
     def keyPressEvent(self: QDialog, event: object) -> None:
         """
             Override close dialog on pressing the Enter key.
         """
-        if not (len(self.form_gui_widget) > 0):
-            if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
-                event.accept()
-            else:
-                super(SophysForm, self).keyPressEvent(event)
+        if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
+            event.accept()
+        else:
+            super(SophysForm, self).keyPressEvent(event)
 
     def selectedItemMetadata(self):
         """

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -41,6 +41,7 @@ class SophysForm(QDialog):
             form_gui_widget = "", max_rows = 3):
         super().__init__()
         self.max_rows = max_rows
+        self.form_gui_widget = form_gui_widget
         self.allowedParameters = allowedParameters
         self.allowedNames = allowedNames
         self.inputWidgets = {}
@@ -51,13 +52,13 @@ class SophysForm(QDialog):
         self.metadata_file_path = None
         self.global_metadata_path = metadata_file_path
         self.itemType = "instruction" if "instruction" in modalMode else "plan"
-        self.setupUi(form_gui_widget)
+        self.setupUi()
 
     def keyPressEvent(self: QDialog, event: object) -> None:
         """
             Override close dialog on pressing the Enter key.
         """
-        if event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return:
+        if (event.key() == Qt.Key_Enter or event.key() == Qt.Key_Return) and not (len(self.form_gui_widget) > 0):
             event.accept()
         else:
             super(SophysForm, self).keyPressEvent(event)
@@ -562,7 +563,7 @@ class SophysForm(QDialog):
 
         return group, currItem
 
-    def setupUi(self, form_gui_widget):
+    def setupUi(self):
         self.setMaximumSize(1500, 1000)
         self.setWindowFlags(Qt.WindowStaysOnTopHint)
 
@@ -571,8 +572,8 @@ class SophysForm(QDialog):
         lay = QVBoxLayout(self)
 
         isAddition = "add" in self.modalMode
-        if len(form_gui_widget) > 0:
-            currItem = form_gui_widget
+        if len(self.form_gui_widget) > 0:
+            currItem = self.form_gui_widget
         else:
             if isAddition:
                 itemCombbox, currItem = self.getGeneralPlanData()

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -201,13 +201,15 @@ class SophysForm(QDialog):
         self.addItemToQueue({"pos": "front"})
         self.model.queue_start()
 
-    def getDialogBtns(self):
+    def getDialogBtns(self, hasAddItemBtn: bool = True):
         """
             Create the form dialog buttons.
         """
-        self.btns = QDialogButtonBox(
-            QDialogButtonBox.Save | QDialogButtonBox.Cancel
-        )
+        self.btns = QDialogButtonBox()
+        if hasAddItemBtn:
+            self.btns = QDialogButtonBox(
+                QDialogButtonBox.Save | QDialogButtonBox.Cancel
+            )
         if "add" in self.modalMode:
             btn = self.btns.addButton("Execute", QDialogButtonBox.ActionRole)
             btn.setIcon(qta.icon("fa5s.play"))

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -38,8 +38,9 @@ class SophysForm(QDialog):
 
     def __init__(
             self, model, modalMode, allowedParameters, allowedNames, hasEnv=True, metadata_file_path="",
-            form_gui_widget = ""):
+            form_gui_widget = "", max_rows = 3):
         super().__init__()
+        self.max_rows = max_rows
         self.allowedParameters = allowedParameters
         self.allowedNames = allowedNames
         self.inputWidgets = {}
@@ -507,7 +508,7 @@ class SophysForm(QDialog):
             pos = [0, 0]
             for paramMeta in parameters:
                 pos = self.addParameterInput(paramMeta, pos, glay)
-                if pos[0] > 4:
+                if pos[0] >= self.max_rows*2:
                     pos[0] = 0
                     pos[1] += 2
 

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -503,7 +503,7 @@ class SophysForm(QDialog):
         """
         itemAllowedParams = None
         retry_count = 0
-        while itemAllowedParams == None or retry_count > 5:
+        while itemAllowedParams == None and retry_count <= 5:
             itemAllowedParams = self.allowedParameters(name=currentItem)
             time.sleep(0.2)
             retry_count += 1

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -507,7 +507,7 @@ class SophysForm(QDialog):
             itemAllowedParams = self.allowedParameters(name=currentItem)
             time.sleep(0.2)
             retry_count += 1
-        if retry_count > 5:
+        if retry_count > 5 and itemAllowedParams is None:
             raise Exception()
 
         group = QGroupBox()

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -1,3 +1,4 @@
+import time
 import typing
 import qtawesome as qta
 import typesentry
@@ -478,7 +479,14 @@ class SophysForm(QDialog):
         """
             Update the current plan input parameters.
         """
-        itemAllowedParams = self.allowedParameters(name=currentItem)
+        itemAllowedParams = None
+        retry_count = 0
+        while itemAllowedParams == None or retry_count > 5:
+            itemAllowedParams = self.allowedParameters(name=currentItem)
+            time.sleep(0.2)
+            retry_count += 1
+        if retry_count > 5:
+            raise Exception()
 
         group = QGroupBox()
         glay = QGridLayout()

--- a/sophys_gui/components/login.py
+++ b/sophys_gui/components/login.py
@@ -5,9 +5,9 @@ from sophys_gui.functions import addLineJumps
 
 class SophysLogin(LoginCNPEM):
 
-    def __init__(self, model):
+    def __init__(self, run_engine):
         super().__init__()
-        self.runEngine = model.run_engine
+        self.runEngine = run_engine
         self.app = QApplication.instance()
         self.login_signal.connect(self.handleToggleUser)
         self._email.setMinimumWidth(150)

--- a/sophys_gui/components/login.py
+++ b/sophys_gui/components/login.py
@@ -1,0 +1,55 @@
+from qtpy.QtWidgets import QApplication
+from suitscase import LoginCNPEM
+from sophys_gui.functions import addLineJumps
+
+
+class SophysLogin(LoginCNPEM):
+
+    def __init__(self, model):
+        super().__init__()
+        self.runEngine = model.run_engine
+        self.app = QApplication.instance()
+        self.login_signal.connect(self.handleToggleUser)
+        self._email.setMinimumWidth(150)
+        self._password.setMinimumWidth(150)
+        tooltip_msg = "Login into the HTTP Server in order to be " \
+            "able to control and operate the Queue Server. Without the login " \
+            "you will be on the observer mode."
+        tooltip_msg = addLineJumps(tooltip_msg)
+        self.setToolTip(tooltip_msg)
+
+    def logoutUser(self):
+        re = self.runEngine
+        re._user_name = 'GUI Client'
+        re._user_group = 'primary'
+        re._client.logout()
+        self.app.saveRunEngineClient(None)
+        self.client_data = None
+
+    def loginUser(self):
+        re = self.runEngine
+        emailWid = self._email
+        passwordWid = self._password
+        username = emailWid.text()
+        password = passwordWid.text()
+        self.client_data = re._client.login(
+            username=username, password=password,
+            provider="ldap/token")
+        if self.client_data:
+            self.app.saveRunEngineClient(re._client)
+            re._user_name = username
+            re._user_group = self._allowed_group
+            emailWid.setText("")
+            passwordWid.setText("")
+        else:
+            self.toggle_login_status()
+            self.logoutUser()
+
+    def handleToggleUser(self, isLogged):
+        """
+            Toggle user permissions.
+        """
+        if isLogged:
+            self.loginUser()
+            return
+        self.logoutUser()

--- a/sophys_gui/components/login.py
+++ b/sophys_gui/components/login.py
@@ -31,6 +31,8 @@ class SophysLogin(LoginCNPEM):
         emailWid = self._email
         passwordWid = self._password
         username = emailWid.text()
+        if "@" in username:
+            username = username.split("@")[0]
         password = passwordWid.text()
         self.client_data = re._client.login(
             username=username, password=password,

--- a/sophys_gui/operation/main.py
+++ b/sophys_gui/operation/main.py
@@ -70,7 +70,7 @@ class SophysOperationGUI(QMainWindow):
         wid.setLayout(glay)
 
         if not self.has_api_key:
-            self.login = SophysLogin(self.model)
+            self.login = SophysLogin(self.model.run_engine)
             self.login.setMaximumWidth(500)
             self.loginChanged = self.login.login_signal
             glay.addWidget(self.login, 0, 2, 1, 1)


### PR DESCRIPTION
Available Sophys GUI Widgets:

Server Model:
This is a class that returns a run engine variable, that allows other widgets to communicate with the http-server service that was specified in the initialization of the run engine variable. This will be running in the background and should not be instantiated inside the GUI window.

SophysForm:
This creates a form widget with all the necessary inputs of a pre specified plan and an execute button to send the command for immediate execution to the http-server. If no used has logged in the used run engine variable a popup will appear notifying the user doesn't have the permission to run the plan.

![image](https://github.com/user-attachments/assets/db483662-f2f8-4d2e-aed5-ed98ce2d5b09)
![image](https://github.com/user-attachments/assets/220774f9-a240-409d-ab43-764fa935d512)

SophysLogin:
This uses the LoginCNPEM widget to authenticate a user in a run engine variable.

![image](https://github.com/user-attachments/assets/5e52bf45-73ae-4eaf-9449-b056cb31dfda)

SophysLed:
This is a widget that can monitor any of the run engine status showing a led or a loading spinner icon according to a condition that is passed in the initialization of the widget.

![image](https://github.com/user-attachments/assets/e59c9f27-7ade-43f7-bbac-74d0abffd1c0)
![image](https://github.com/user-attachments/assets/8a914d68-e73e-4554-9fae-0568359465cc)

SophysApplication:
This is a wrapper around a QApplication that allows the other widgets to report errors that might occur during the communication with the http-server like if the user is not authenticated.

Example in an operation GUI:
![image](https://github.com/user-attachments/assets/af7f983f-bab1-4f6b-8d46-fd47c741f081)
