### PR TITLE
Make sophys form widget more generic for use in external GUIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sophys-gui',
-    version='0.8.3',
+    version='0.9.0',
     author='SWC - LNLS',
     description='Control GUI for the Bluesky queue.',
     install_requires=[

--- a/sophys_gui/__init__.py
+++ b/sophys_gui/__init__.py
@@ -2,7 +2,5 @@
     This is a GUI for controlling and monitoring a Blueksy instance through HTTP Server and Kafka.
 """
 from .server.model import ServerModel
-from .components.application import SophysApplication
-from .components.form import SophysForm
-from .components.login import SophysLogin
-from .components.led import SophysLed
+from .components import SophysForm, SophysLogin, \
+    SophysLed, QueueController, SophysApplication

--- a/sophys_gui/components/__init__.py
+++ b/sophys_gui/components/__init__.py
@@ -7,3 +7,5 @@ from .input import SophysInputList, SophysInputDict, SophysSpinBox, \
     SophysInputMotor
 from .console import SophysConsoleMonitor
 from .login import SophysLogin
+from .led import SophysLed
+from .form import SophysForm

--- a/sophys_gui/components/application.py
+++ b/sophys_gui/components/application.py
@@ -112,15 +112,16 @@ class SophysApplication(QApplication):
         """
             Create a hidden popup widget.
         """
-        popup = PopupWidget(window)
-        popup.setVisible(False)
-        popup.setStyleSheet("""
-            margin: 1em;
-            background-color: #ffdb3b;
-            border: 1px solid #808080;
-            border-radius: 10px;
-        """)
-        self.popup.append(popup)
+        if isinstance(self.popup, list):
+            popup = PopupWidget(window)
+            popup.setVisible(False)
+            popup.setStyleSheet("""
+                margin: 1em;
+                background-color: #ffdb3b;
+                border: 1px solid #808080;
+                border-radius: 10px;
+            """)
+            self.popup.append(popup)
 
     def saveRunEngineClient(self, client):
         self.runEngineClient = client

--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -6,7 +6,7 @@ from math import floor
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QDialog, QDialogButtonBox, QGridLayout, \
     QComboBox, QGroupBox, QHBoxLayout, QLineEdit, QLabel, QVBoxLayout, \
-    QApplication, QCompleter, QComboBox
+    QApplication, QCompleter, QComboBox, QWidget
 from sophys_gui.functions import evaluateValue, getMotorInput
 from ..input import SophysInputList, SophysInputDict, SophysSpinBox, \
     SophysInputMotor
@@ -38,8 +38,9 @@ class SophysForm(QDialog):
 
     def __init__(
             self, model, modalMode, allowedParameters, allowedNames, hasEnv=True, metadata_file_path="",
-            form_gui_widget = "", max_rows = 3):
+            form_gui_widget = "", max_rows = 3, showOnlyInputs = False):
         super().__init__()
+        self.showOnlyInputs = showOnlyInputs
         self.max_rows = max_rows
         self.form_gui_widget = form_gui_widget
         self.allowedParameters = allowedParameters
@@ -512,16 +513,19 @@ class SophysForm(QDialog):
             retry_count += 1
         if retry_count > 5 and itemAllowedParams is None:
             raise Exception()
+        self.chosenItem = itemAllowedParams["name"]
 
-        group = QGroupBox()
+        if self.showOnlyInputs:
+            group = QWidget()
+        else:
+            group = QGroupBox()
+            group.setTitle(self.chosenItem)
+
         glay = QGridLayout()
         group.setLayout(glay)
 
         if "description" in itemAllowedParams and self.plan_description != None:
             self.plan_description.setText(itemAllowedParams["description"])
-
-        self.chosenItem = itemAllowedParams["name"]
-        group.setTitle(self.chosenItem)
 
         hasParameters = "parameters" in itemAllowedParams
         if hasParameters:
@@ -577,7 +581,10 @@ class SophysForm(QDialog):
         self.setMaximumSize(1500, 1000)
         self.setWindowFlags(Qt.WindowStaysOnTopHint)
 
-        self.group = QGroupBox()
+        if self.showOnlyInputs:
+            self.group = QWidget()
+        else:
+            self.group = QGroupBox()
         self.parametersLayout = QGridLayout()
         lay = QVBoxLayout(self)
 

--- a/sophys_gui/components/queue_controller/main.py
+++ b/sophys_gui/components/queue_controller/main.py
@@ -18,12 +18,13 @@ class QueueController(QWidget):
 
     """
 
-    def __init__(self, model, loginChanged):
+    def __init__(self, run_engine, loginChanged, execution_monitor=False):
         super().__init__()
-        self.run_engine = model.run_engine
+        self.run_engine = run_engine
         self.updateEvent = self.run_engine.events.status_changed
         self.reStatus = self.run_engine.re_manager_status
         self.isLogged = False
+        self.execution_monitor = execution_monitor
         self.cmdStacks = []
 
         self._setupUi(loginChanged)
@@ -127,7 +128,10 @@ class QueueController(QWidget):
         group.setMinimumWidth(300)
         hlay.setContentsMargins(25, 2, 25, 2)
 
-        for cmdBtnKey in ["start", "stop", "help"]:
+        queue_stacks = ["start", "stop", "help"]
+        if self.execution_monitor:
+            queue_stacks = ["start_monitor", "stop", "help"]
+        for cmdBtnKey in queue_stacks:
             self.addControlButton(cmdBtnKey, hlay)
 
         return group
@@ -143,8 +147,12 @@ class QueueController(QWidget):
 
     def _setupUi(self, loginChanged):
         hlay = QHBoxLayout(self)
+        
 
-        self.addStatusLeds(hlay)
+        if not self.execution_monitor:
+            self.addStatusLeds(hlay)
+        else:
+            self.cmdStacks.append(QStackedWidget())
 
         group = self.getQueueController()
         hlay.addWidget(group)

--- a/sophys_gui/components/queue_controller/util.py
+++ b/sophys_gui/components/queue_controller/util.py
@@ -19,11 +19,32 @@ CONFIG = {
             "tooltip": "Resume running the paused queue item."
         }
     ],
+    "start_monitor": [
+        {
+            'icon': 'fa5s.play',
+            'title': 'Start',
+            'cmd': lambda _: print(""),
+            'enabled': False,
+            "tooltip": "Start running the first queue item."
+        },
+        {
+            'icon': 'fa5s.pause',
+            'title': 'Pause',
+            'cmd': lambda re: re.re_pause(option='deferred'),
+            "tooltip": "Pause the running item."
+        },
+        {
+            'icon': 'fa5s.play',
+            'title': 'Resume',
+            'cmd': lambda re: re.re_resume(),
+            "tooltip": "Resume running the paused queue item."
+        }
+    ],
     "stop": [
         {
             'icon': 'fa5s.stop',
             'title': 'Stop',
-            'cmd': lambda _: print(""),
+            'cmd': lambda re: re.re_pause(option="deferred"),
             'enabled': False,
             "tooltip": "Stop running the queue list."
         },
@@ -45,7 +66,7 @@ CONFIG = {
         {
             'icon': 'fa5s.pause-circle',
             'title': 'Pause Now',
-            'cmd': lambda _: print(""),
+            'cmd': lambda re: re.re_pause(option="deferred"),
             'enabled': False,
             "tooltip": "Pause the execution now. This may cause the plan to fail later."
         },

--- a/sophys_gui/operation/main.py
+++ b/sophys_gui/operation/main.py
@@ -75,7 +75,7 @@ class SophysOperationGUI(QMainWindow):
             self.loginChanged = self.login.login_signal
             glay.addWidget(self.login, 0, 2, 1, 1)
 
-        controller = QueueController(self.model, self.loginChanged)
+        controller = QueueController(self.model.run_engine, self.loginChanged)
         glay.addWidget(controller, 0, 0, 1, 3 if self.has_api_key else 2)
 
         vsplitter = QSplitter(Qt.Vertical)


### PR DESCRIPTION
- Handle error being raised if the parent doesn't have a proper popup widget handler.
- Add parameter to toggle the widget between groupbox(Has a title) and widget form  


<img width="1120" height="804" alt="image" src="https://github.com/user-attachments/assets/9ea4f849-273d-4ccf-8fca-1095af5609d4" />

Parametrize the QueueController for monitoring and controlling the queue only. This is useful if you use together with the SophysForm widget.
<img width="1039" height="70" alt="image" src="https://github.com/user-attachments/assets/d0235b3c-549c-4cfe-8a2c-bad93bf5c8fc" />

