### PR TITLE
Include match contains filter on combobox inputs

### DIFF
--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -362,6 +362,7 @@ class SophysForm(QDialog):
         combobox = QComboBox()
         combobox.setEditable(True)
         combobox.completer().setCompletionMode(QCompleter.PopupCompletion)
+        combobox.completer().setFilterMode(Qt.MatchContains)
         insert_mode = QComboBox.InsertAlphabetically if insertAvailable else QComboBox.NoInsert
         combobox.setInsertPolicy(insert_mode)
 
@@ -566,6 +567,7 @@ class SophysForm(QDialog):
         combobox = QComboBox()
         combobox.setEditable(True)
         combobox.completer().setCompletionMode(QCompleter.PopupCompletion)
+        combobox.completer().setFilterMode(Qt.MatchContains)
         combobox.setInsertPolicy(QComboBox.NoInsert)
         allowedNames = self.allowedNames()
         combobox.addItems(sorted(allowedNames))

--- a/sophys_gui/components/input/list.py
+++ b/sophys_gui/components/input/list.py
@@ -192,6 +192,7 @@ class SophysInputList(QWidget):
         wid = QComboBox()
         wid.setEditable(True)
         wid.completer().setCompletionMode(QCompleter.PopupCompletion)
+        wid.completer().setFilterMode(Qt.MatchContains)
         wid.setInsertPolicy(QComboBox.NoInsert)
         wid.addItems(sorted(self.availableItems))
         return wid


### PR DESCRIPTION
Add filter to include all the results that contain the specified pattern inserted in the combobox line edit.
Ex.: The 'det' string will include 'noisy_det', 'det' and 'det1'.

