### PR TITLE
Remove queue server logs by default

### DIFF
--- a/sophys_gui/__main__.py
+++ b/sophys_gui/__main__.py
@@ -17,13 +17,16 @@ def main():
     parser.add_argument("--kafka-bootstrap", required=True, help="The Kafka broker address to connect to. (e.g. 127.0.0.1:kafka_port)")
     parser.add_argument("--kafka-topic", required=True, help="The Kafka topic to listen to. (e.g. test_bluesky_raw_docs)")
     parser.add_argument("--reading-order", required=False, default='up_down', help="The reading order of the parameters in the form for the addition of a new plan.")
+    parser.add_argument("--show-all-logs", required=False, default=False, help="Don't hide the queue server logs")
     args = parser.parse_args()
 
     __backend_model = ServerModel(args.http_server, args.http_server_api_key)
 
     app = SophysApplication(sys.argv)
     has_api_key = True if args.http_server_api_key else False
-    window = SophysOperationGUI(__backend_model, args.kafka_bootstrap, args.kafka_topic, has_api_key, args.reading_order)
+    window = SophysOperationGUI(
+        __backend_model, args.kafka_bootstrap, args.kafka_topic, 
+        has_api_key, args.reading_order, args.show_all_logs)
     window.setWindowIcon(qtawesome.icon("mdi.cloud", color="#ffffff"))
     window.setWindowTitle("SOPHYS GUI")
     window.show()

--- a/sophys_gui/components/console.py
+++ b/sophys_gui/components/console.py
@@ -21,9 +21,9 @@ class SophysConsoleMonitor(QScrollArea):
 
     appendLine = Signal(str)
 
-    def __init__(self, model):
+    def __init__(self, model, all_logs=False):
         super().__init__()
-
+        self.all_logs = all_logs
         self.run_engine = model.run_engine
         self.appendLine.connect(self.onAppendLine)
 
@@ -46,7 +46,8 @@ class SophysConsoleMonitor(QScrollArea):
             if newOutput:
                 new_console_line = newOutput[1].strip()
                 if new_console_line != "":
-                    self.appendLine.emit(new_console_line)
+                    if not "bluesky_queueserver" in new_console_line or self.all_logs:
+                        self.appendLine.emit(new_console_line)
             else:
                 break
 

--- a/sophys_gui/operation/main.py
+++ b/sophys_gui/operation/main.py
@@ -11,9 +11,9 @@ class SophysOperationGUI(QMainWindow):
 
     loginChanged = Signal([bool])
 
-    def __init__(self, model, kafka_ip, kafka_topic, has_api_key=False, reading_order='up_down'):
+    def __init__(self, model, kafka_ip, kafka_topic, has_api_key=False, reading_order='up_down', all_logs=False):
         super().__init__()
-
+        self.all_logs = all_logs
         self._kafka_ip = kafka_ip
         self._kafka_topic = kafka_topic
         self.has_api_key = has_api_key
@@ -60,7 +60,7 @@ class SophysOperationGUI(QMainWindow):
         live_view = LiveView(self._kafka_topic, self._kafka_ip, visual_elements)
         monitorTabs.addTab(live_view, "Live View")
 
-        console = SophysConsoleMonitor(self.model)
+        console = SophysConsoleMonitor(self.model, self.all_logs)
         monitorTabs.addTab(console, "Console")
 
         return monitorTabs


### PR DESCRIPTION
The queue server logs can be seen setting the flag --show-all-logs to True.