### PR TITLE
Reload permissions on login

### DIFF
--- a/sophys_gui/components/login.py
+++ b/sophys_gui/components/login.py
@@ -43,6 +43,7 @@ class SophysLogin(LoginCNPEM):
             re._user_group = self._allowed_group
             emailWid.setText("")
             passwordWid.setText("")
+            re._client.permissions_reload()
         else:
             self.toggle_login_status()
             self.logoutUser()


### PR DESCRIPTION
Reload user permissions after login in order to fetch the updated allowed plans and devices.