### PR TITLE
Fix args bug

### DIFF
--- a/sophys_gui/components/form/main.py
+++ b/sophys_gui/components/form/main.py
@@ -212,7 +212,6 @@ class SophysForm(QDialog):
         itemParameters = self.getItemParameters()
         item = self.getItemMetadata(itemParameters)
         isItemUpdate = "edit" in self.modalMode
-        
         if isItemUpdate:
             self.model.queue_item_update(item=item)
         else:
@@ -291,7 +290,8 @@ class SophysForm(QDialog):
             item = argsParams[0]
         elif isMotors:
             argsParams = argsParams.copy()
-            argsParams.pop(0)
+            if isinstance(argsParams[0], list):
+                argsParams.pop(0)
             item = argsParams
         return item
 

--- a/sophys_gui/functions.py
+++ b/sophys_gui/functions.py
@@ -77,7 +77,8 @@ def addArgsToKwargs(argsList):
         Concatenate arguments and keyword arguments.
     """
     args = argsList[0].copy()
-    argsList[1]["detectors"] = args.pop(0)
+    if isinstance(args[0][0], list):
+        argsList[1]["detectors"] = args.pop(0)
     argsList[1]["args"] = args
 
 def getMotorInput(paramMeta):


### PR DESCRIPTION
Fix args first parameter always being considered a detector, due to this being the standard behaviour in bluesky plans, now there is a validation to see if the first args item is a list, and if so it's considered a detector parameter.