### PR TITLE
Remove pyepics installation from mamba environment

### DIFF
--- a/sophys_gui.yml
+++ b/sophys_gui.yml
@@ -6,7 +6,6 @@ dependencies:
     - qtawesome==1.4.0
     - bluesky-queueserver-api==0.0.10
     - bluesky-widgets>=0.0.15
-    - pyepics==3.5.2
     - pip==23.1.2
     - python<3.12.0
     - pyqt==5.15.9


### PR DESCRIPTION
We don't use pyepics directly in this project, so we can depend on `suitscase` specifying the allowed version on its own. This avoids installing an older version of pyepics, which is not supported anymore, and leads to errors (in particular, `ModuleNotFoundError: No module named 'pkg_resources'`, fixed in pyepics `3.5.3`).